### PR TITLE
#118-highlite-selected-job-card-AliDashti

### DIFF
--- a/client/src/components/JobCard.css
+++ b/client/src/components/JobCard.css
@@ -13,7 +13,7 @@
     background: #f5f5f5;
     box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.1);
   transition: transform 0.2s ease-in-out, background-color 0.2s ease-in-out;
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.30rem;
   background: #f5f5f5;
   box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
Fixes #118 a pull request made by mistake from main to main this ticket is explaining the changes:
Modify the `JobCard.jsx`, and `JobCard.css` so when a user click on a job card, the job card is highlighted and stays highlighted until another card is clicked.

Desired highlight Behavior:

**Default Highlight:**

- When the homepage loads, the first job card is automatically highlighted.

**Deselect on New Selection:**

- When a different job card is clicked, the previous highlight is removed, and the new job card gets highlighted.

**Single Selection:**

- Only one job card can be highlighted at a time.
- Clicking on a different job card deselects the previously highlighted card and highlights the new selection.

## Checklist:

- [ ] I have carefully reviewed my own code

